### PR TITLE
Synchronizer API changes

### DIFF
--- a/examples/reader.rs
+++ b/examples/reader.rs
@@ -8,7 +8,7 @@ fn main() {
     let mut synchronizer = Synchronizer::new("/tmp/hello_world");
 
     // Read data from shared memory
-    let data = unsafe { synchronizer.read::<HelloWorld>() }.expect("failed to read data");
+    let data = unsafe { synchronizer.read::<HelloWorld>(false) }.expect("failed to read data");
 
     // Access fields of the struct
     println!("version: {} | messages: {:?}", data.version, data.messages);

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -6,7 +6,7 @@ use crate::synchronizer::SynchronizerError::*;
 /// - data size (<549 GB) - 39 bits
 /// - data checksum       - 24 bits
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) struct InstanceVersion(u64);
+pub struct InstanceVersion(pub(crate) u64);
 
 const DATA_SIZE_BITS: usize = 39;
 const DATA_CHECKSUM_BITS: usize = 24;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,6 @@
 //! To get started with `mmap-sync`, please see the [examples](https://github.com/cloudflare/mmap-sync/tree/main/examples) provided.
 mod data;
 pub mod guard;
-mod instance;
+pub mod instance;
 mod state;
 pub mod synchronizer;


### PR DESCRIPTION
Implemented the following changes:
* Added `check_bytes` parameter for `Synchronizer::read` to allow checking whether mapped memory can be used with type `T`.
* Added `Synchronizer::version` method, returning current `InstanceVersion`, useful for detecting whether synchronized `entity` has changed