### PR TITLE
Add repr(C) attribute for State type

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -14,6 +14,7 @@ const STATE_SIZE: usize = mem::size_of::<State>();
 const SLEEP_DURATION: Duration = Duration::from_secs(1);
 
 /// State stored in memory for synchronization using atomics
+#[repr(C)]
 pub(crate) struct State {
     /// Current data instance version
     version: AtomicU64,


### PR DESCRIPTION
Struct memory layout can change between Rust compiler versions fpr `#[repr(Rust)]` structs. Because we persist the `State` struct to disk, we should fix the layout with `#[repr(C)]` to prevent potential incompatibility.

Testing on x86_64 and aarch64 shows no layout differences with this change.