### PR TITLE
Style Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The templated type `T` for `Synchronizer` can be any Rust struct implementing sp
 To use `mmap-sync`, add it to your `Cargo.toml` under `[dependencies]`:
 ```toml
 [dependencies]
-mmap-sync = "1"
+mmap-sync = "2.0.0"
 ```
 Then, import `mmap-sync` in your Rust program:
 ```rust

--- a/benches/synchronizer.rs
+++ b/benches/synchronizer.rs
@@ -30,11 +30,11 @@ fn build_mock_data() -> (HelloWorld, AlignedVec) {
     (data, bytes)
 }
 
-fn derive_shm_path(subpath : &str) -> String {
-    const EV_NAME : &str = "MMAPSYNC_BM_ROOTDIR";
-    const DEFAULT_ROOT : &str = "/dev/shm"; // respect original functionality
+fn derive_shm_path(subpath: &str) -> String {
+    const EV_NAME: &str = "MMAPSYNC_BM_ROOTDIR";
+    const DEFAULT_ROOT: &str = "/dev/shm"; // respect original functionality
 
-    let selected_root : String = match env::var(EV_NAME) {
+    let selected_root: String = match env::var(EV_NAME) {
         Ok(val) => {
             let requested_root = val.trim();
 
@@ -54,10 +54,8 @@ fn derive_shm_path(subpath : &str) -> String {
                     DEFAULT_ROOT.into()
                 }
             }
-        },
-        Err(_e) => {
-            DEFAULT_ROOT.into()
         }
+        Err(_e) => DEFAULT_ROOT.into(),
     };
 
     format!("{selected_root}/{subpath}")

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -17,7 +17,6 @@ use std::ops::Deref;
 
 use crate::instance::InstanceVersion;
 use crate::state::State;
-use crate::synchronizer::SynchronizerError;
 
 /// An RAII implementation of a “scoped read lock” of a `State`
 pub(crate) struct ReadGuard<'a> {
@@ -27,12 +26,9 @@ pub(crate) struct ReadGuard<'a> {
 
 impl<'a> ReadGuard<'a> {
     /// Creates new `ReadGuard` with specified parameters
-    pub(crate) fn new(
-        state: &'a mut State,
-        version: InstanceVersion,
-    ) -> Result<Self, SynchronizerError> {
+    pub(crate) fn new(state: &'a mut State, version: InstanceVersion) -> Self {
         state.rlock(version);
-        Ok(ReadGuard { version, state })
+        ReadGuard { version, state }
     }
 }
 

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -52,9 +52,9 @@ pub struct ReadResult<'a, T: Archive> {
 
 impl<'a, T: Archive> ReadResult<'a, T> {
     /// Creates new `ReadResult` with specified parameters
-    pub(crate) fn new(_guard: ReadGuard<'a>, entity: &'a Archived<T>, switched: bool) -> Self {
+    pub(crate) fn new(guard: ReadGuard<'a>, entity: &'a Archived<T>, switched: bool) -> Self {
         ReadResult {
-            _guard,
+            _guard: guard,
             entity,
             switched,
         }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -36,7 +36,7 @@ impl<'a> ReadGuard<'a> {
     }
 }
 
-impl<'a> Drop for ReadGuard<'a> {
+impl Drop for ReadGuard<'_> {
     /// Unlocks stored `version` when `ReadGuard` goes out of scope
     fn drop(&mut self) {
         self.state.runlock(self.version);
@@ -66,7 +66,7 @@ impl<'a, T: Archive> ReadResult<'a, T> {
     }
 }
 
-impl<'a, T: Archive> Deref for ReadResult<'a, T> {
+impl<T: Archive> Deref for ReadResult<'_, T> {
     type Target = Archived<T>;
 
     /// Dereferences stored `entity` for easier access

--- a/src/locks.rs
+++ b/src/locks.rs
@@ -77,11 +77,11 @@ impl<'a> WriteLockStrategySealed<'a> for LockDisabled {
     }
 }
 
-impl<'a> WriteLockStrategy<'a> for LockDisabled {}
+impl WriteLockStrategy<'_> for LockDisabled {}
 
 pub struct DisabledGuard<'a>(&'a mut MmapMut);
 
-impl<'a> Deref for DisabledGuard<'a> {
+impl Deref for DisabledGuard<'_> {
     type Target = MmapMut;
 
     fn deref(&self) -> &Self::Target {
@@ -89,7 +89,7 @@ impl<'a> Deref for DisabledGuard<'a> {
     }
 }
 
-impl<'a> DerefMut for DisabledGuard<'a> {
+impl DerefMut for DisabledGuard<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut *self.0
     }
@@ -145,14 +145,14 @@ impl<'a> WriteLockStrategySealed<'a> for SingleWriter {
 }
 
 #[cfg(unix)]
-impl<'a> WriteLockStrategy<'a> for SingleWriter {}
+impl WriteLockStrategy<'_> for SingleWriter {}
 
 /// A simple guard which does not release the lock upon being dropped.
 #[cfg(unix)]
 pub struct SingleWriterGuard<'a>(&'a mut MmapMut);
 
 #[cfg(unix)]
-impl<'a> Deref for SingleWriterGuard<'a> {
+impl Deref for SingleWriterGuard<'_> {
     type Target = MmapMut;
 
     fn deref(&self) -> &Self::Target {
@@ -161,7 +161,7 @@ impl<'a> Deref for SingleWriterGuard<'a> {
 }
 
 #[cfg(unix)]
-impl<'a> DerefMut for SingleWriterGuard<'a> {
+impl DerefMut for SingleWriterGuard<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut *self.0
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -162,7 +162,7 @@ impl<'a, WL: WriteLockStrategy<'a>> StateContainer<WL> {
 
         let mut need_init = false;
         // Reset state file size to match exactly `STATE_SIZE`
-        if state_file.metadata().map_err(FailedStateRead)?.len() as usize != STATE_SIZE {
+        if state_file.metadata().map_err(FailedStateRead)?.len() != STATE_SIZE as u64 {
             state_file
                 .set_len(STATE_SIZE as u64)
                 .map_err(FailedStateRead)?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -72,9 +72,8 @@ impl State {
                 num_readers.store(0, Ordering::SeqCst);
                 reset = true;
                 break;
-            } else {
-                thread::sleep(sleep_duration);
             }
+            thread::sleep(sleep_duration);
         }
 
         (next_idx, reset)
@@ -175,9 +174,9 @@ impl<'a, WL: WriteLockStrategy<'a>> StateContainer<WL> {
             let new_state = State::default();
             unsafe {
                 mmap.as_mut_ptr()
-                    .copy_from((&new_state as *const State) as *const u8, STATE_SIZE)
-            };
-        };
+                    .copy_from((&new_state as *const State) as *const u8, STATE_SIZE);
+            }
+        }
 
         self.mmap = Some(WL::new(mmap, state_file));
         Ok(())

--- a/src/synchronizer.rs
+++ b/src/synchronizer.rs
@@ -219,7 +219,7 @@ where
     pub unsafe fn read<T>(
         &'a mut self,
         check_bytes: bool,
-    ) -> Result<ReadResult<T>, SynchronizerError>
+    ) -> Result<ReadResult<'a, T>, SynchronizerError>
     where
         T: Archive,
         T::Archived: for<'b> CheckBytes<DefaultValidator<'b>>,

--- a/src/synchronizer.rs
+++ b/src/synchronizer.rs
@@ -231,7 +231,7 @@ where
         let version = state.version()?;
 
         // create and lock state guard for reading
-        let guard = ReadGuard::new(state, version)?;
+        let guard = ReadGuard::new(state, version);
 
         // fetch data for current version from mapped memory
         let (data, switched) = self.data_container.data(version)?;


### PR DESCRIPTION
- Apply style changes, addressing new clippy lints for lifetime elision as well as several pedantic lints which are disabled by default.
- Apply a small change to cast order to make a cast infallible on 32-bit targets.
- Run `cargo fmt` to standardize formatting.